### PR TITLE
socat friendly command

### DIFF
--- a/start-socat.sh
+++ b/start-socat.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-env | grep _TCP= | grep -v SERF | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -ls TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/'  | sh
+env | grep _TCP= | grep -v SERF | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -ls TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3/'  | sh


### PR DESCRIPTION
tested with simple fig
amb:
 build: /projects/docker-ambassador
 links:
- simple
  ports:
- 8000:8000

simple:
 image: centos
 command: python -m SimpleHTTPServer
 ports:
- 8000

simplecli:
 image: ubuntu
 command: /bin/sh -c "curl `env | grep ADDR | cut -f2 -d'='`:8000"
 links:
- amb:amb
